### PR TITLE
meta: add flaky test issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.md
+++ b/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.md
@@ -1,0 +1,26 @@
+---
+name: Report a flaky test
+about: Report a flaky test in our CI
+labels: "CI / flaky test"
+
+---
+
+<!--
+Thank you for reporting an flaky test.
+
+Please fill in as much of the template below as you're able.
+
+Test: The test that is flaky - e.g. `test-fs-stat-bigint`
+Platform: The platform the test is flaky on - e.g. `macos` or `linux`
+Console Output: A pasted console output from a failed CI job showing the whole failure of the test
+Build Links: Links to builds affected by the flaky test
+Failure Rate: How often does this test fail - e.g. 1 in 10 builds
+
+If possible please try to give a timeframe to the when the test started failing to assist with investigation
+-->
+
+* **Test**:
+* **Platform**:
+* **Console Output**:
+* **Build Links**:
+* **Failure Rate**:


### PR DESCRIPTION
Add a flaky test issue template to ensure that enough information is provided for investigation